### PR TITLE
eliminate darkmode bands on mobile

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -25,6 +25,8 @@ function App() {
 
   const flipThemeHandler = () => {
     const newTheme = !isDarkMode;
+
+    document.body.className = newTheme ? 'bg-dark' : 'bg-light';
     setIsDarkMode(newTheme);
   };
 


### PR DESCRIPTION
body had a bg-dark class, didn't show up on desktop or mobile view but does show up on a physical phone.