### PR TITLE
replace date parsing with simple string parse

### DIFF
--- a/src/components/tables/WatchlistRow.js
+++ b/src/components/tables/WatchlistRow.js
@@ -7,7 +7,6 @@ const WatchlistRow = (props) => {
 
   const parseData = (type, val) => {
     if (type === 'date') {
-      console.log(val)
       const dateChunks = val.split('-')
       return `${dateChunks[1]}/${dateChunks[2]}`;
     } else if (type === 'price') {

--- a/src/components/tables/WatchlistRow.js
+++ b/src/components/tables/WatchlistRow.js
@@ -7,11 +7,9 @@ const WatchlistRow = (props) => {
 
   const parseData = (type, val) => {
     if (type === 'date') {
-      const d = new Date(val + ' EST');
-      return d.toLocaleString('en-US', {
-        month: '2-digit',
-        day: '2-digit',
-      });
+      console.log(val)
+      const dateChunks = val.split('-')
+      return `${dateChunks[1]}/${dateChunks[2]}`;
     } else if (type === 'price') {
       return `$${val.toFixed(2)}`;
     } else if (type === 'percentage') {


### PR DESCRIPTION
for some reason mobile doesn't want to parse dates the way it was set up - this just does a string parse and works from what I can test on an iphone. resolves #57 